### PR TITLE
Adding support for setting the -derivedDataPath xcodebuild option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ A list of tests to skip.
 
 Arbitrary, space separated build settings (e.g. `PLATFORM_NAME=iphonesimulator`).
 
+### `derived-data-path`
+
+Override the folder that should be used for derived data
+
 ### `action`
 
 The action to perform (e.g. build, test, ...).<br/>

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   skip-testing:
     description: A list of tests to skip.
     required: false
+  derived-data-path:
+    description: Override the folder that should be used for derived data
+    required: false
   build-settings:
     description: Arbitrary, space separated build settings (e.g. PLATFORM_NAME=iphonesimulator).
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,10 @@ async function main() {
     if (skipTesting) {
         xcodebuildArgs.push('-skip-testing', skipTesting);
     }
+    const derivedDataPath = core.getInput('derived-data-path');
+    if (derivedDataPath) {
+        xcodebuildArgs.push('-derivedDataPath', derivedDataPath);
+    }
     const buildSettings = core.getInput('build-settings');
     if (buildSettings) {
         xcodebuildArgs.push(...buildSettings.split(' '));


### PR DESCRIPTION
This PR just adds support for specifying the `-derivedDataPath` option to xcodebuild. This is useful when using the Action to build a repository and specifying that the resulting binary should be put in a directory of your choosing. It simplifies storing artifacts from the build or test runs into GitHub Actions.