### PR TITLE
Add new options - including test plans

### DIFF
--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -153,10 +153,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -187,10 +187,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \
@@ -252,10 +252,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -287,10 +287,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \
@@ -352,10 +352,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -387,10 +387,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \

--- a/.github/workflows/master-deploy.yml
+++ b/.github/workflows/master-deploy.yml
@@ -133,6 +133,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -150,6 +153,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -158,6 +163,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -179,6 +187,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -187,6 +197,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \
@@ -218,6 +231,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -236,6 +252,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -244,6 +262,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -266,6 +287,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -274,6 +297,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \
@@ -305,6 +331,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -323,6 +352,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -331,6 +362,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -353,6 +387,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -361,6 +397,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -122,6 +122,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -144,6 +147,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -152,6 +157,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -173,6 +181,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -181,6 +191,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \
@@ -211,6 +224,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -234,6 +250,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -242,6 +260,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -264,6 +285,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -272,6 +295,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \
@@ -302,6 +328,9 @@ jobs:
         result-bundle-path: [ here/and/there.bundle ]
         result-bundle-version: [ 3 ]
         derived-data-path: [ there/and/here/ ]
+        xcroot: [ this/and/that.xcroot ]
+        xctestrun: [ this/and/that.xctestrun ]
+        test-plan: [ SomeTestPlan ]
         skip-testing: [ this ]
         build-settings: [ ABC=DEF ]
         action: [ action ]
@@ -325,6 +354,8 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
           enable-address-sanitizer: false
@@ -333,6 +364,9 @@ jobs:
           result-bundle-path: ${{matrix.result-bundle-path}}
           result-bundle-version: ${{matrix.result-bundle-version}}
           derived-data-path: ${{matrix.derived-data-path}}
+          xcroot: ${{matrix.xcroot}}
+          xctestrun: ${{matrix.xctestrun}}
+          test-plan: ${{matrix.test-plan}}
           skip-testing: ${{matrix.skip-testing}}
           skip-unavailable-actions: true
           allow-provisioning-updates: true
@@ -355,6 +389,8 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
           -enableAddressSanitizer NO \
@@ -363,6 +399,9 @@ jobs:
           -resultBundlePath ${{matrix.result-bundle-path}} \
           -resultBundleVersion ${{matrix.result-bundle-version}} \
           -derivedDataPath ${{matrix.derived-data-path}} \
+          -xcroot ${{matrix.xcroot}} \
+          -xctestrun ${{matrix.xctestrun}} \
+          -testPlan ${{matrix.test-plan}} \
           -skip-testing ${{matrix.skip-testing}} \
           -skipUnavailableActions \
           -allowProvisioningUpdates \

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -147,10 +147,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -181,10 +181,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \
@@ -250,10 +250,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -285,10 +285,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \
@@ -354,10 +354,10 @@ jobs:
           xcconfig: ${{matrix.xcconfig}}
           jobs: ${{matrix.jobs}}
           parallelize-targets: true
-          quiet: true
-          hide-shell-script-environment: true
           enable-code-coverage: true
           parallel-testing-enabled: true
+          quiet: true
+          hide-shell-script-environment: true
           enable-address-sanitizer: false
           enable-thread-sanitizer: false
           enable-undefined-behavior-sanitizer: false
@@ -389,10 +389,10 @@ jobs:
           -xcconfig ${{matrix.xcconfig}} \
           -jobs ${{matrix.jobs}} \
           -parallelizeTargets \
-          -quiet \
-          -hideShellScriptEnvironment \
           -enableCodeCoverage YES \
           -parallel-testing-enabled YES \
+          -quiet \
+          -hideShellScriptEnvironment \
           -enableAddressSanitizer NO \
           -enableThreadSanitizer NO \
           -enableUndefinedBehaviorSanitizer NO \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ The number of jobs to use for building. See also `xcodebuild`'s `-jobs`.
 
 If `true`, the targets will be built in parallel. See also `xcodebuild`'s `-parallelizeTargets`.
 
+### `quiet`
+
+If `true`, `xcodebuild` won't print anything except warnings and errors. See also `xcodebuild`'s `-quiet`.
+
+### `hide-shell-script-environment`
+
+If `true`, `xcodebuild` won't print the environment for shell build scripts. See also `xcodebuild`'s `-hideShellScriptEnvironment`.
+
 ### `enable-code-coverage`
 
 If `true`, code coverage is enabled while testing. See also `xcodebuild`'s `-enableCodeCoverage`.
@@ -86,7 +94,19 @@ The version that should be used for the result bundle. See also `xcodebuild`'s `
 
 ### `derived-data-path`
 
-Override the folder that should be used for derived data
+The path that should be used for derived data. See also `xcdodebuild`'s `-derivedDataPath`.
+
+### `xcroot`
+
+The path to a .xcroot to use for building and/or testing. See also `xcodebuild`'s `-xcroot`.
+
+### `xctestrun`
+
+The path to a test run specification. See also `xcodebuild`'s `-xctestrun`.
+
+### `test-plan`
+
+The name of the test plan associated with the scheme to use for testing. See also `xcodebuild`'s `-testPlan`.
 
 ### `skip-testing`
 
@@ -117,6 +137,7 @@ Default: `test`
 
 Whether the output of `xcodebuild` should be forwarded to `xcpretty`.<br/>
 Default: `true`
+
 
 ## Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,12 @@ inputs:
   parallel-testing-enabled:
     description: If `true`, tests are executed in parallel. See also `xcodebuild`'s `-parallel-testing-enabled`.
     required: false
+  quiet:
+    description: If `true`, xcodebuild won't print anything except warnings and errors. See also `xcodebuild`'s `-quiet`.
+    required: false
+  hide-shell-script-environment:
+    description: If `true`, xcodebuild won't print the environment for shell build scripts. See also `xcodebuild`'s `-hideShellScriptEnvironment`.
+    required: false
   enable-address-sanitizer:
     description: Whether the address sanitizer should be enabled. See also `xcodebuild`'s `-enableAddressSanitizer`.
     required: false
@@ -60,7 +66,16 @@ inputs:
     description: The version that should be used for the result bundle. See also `xcodebuild`'s `-resultBundleVersion`.
     required: false
   derived-data-path:
-    description: Tthe path that should be used for derived data. See also `xcodebuild`'s `-derivedDataPath`.
+    description: The path that should be used for derived data. See also `xcodebuild`'s `-derivedDataPath`.
+    required: false
+  xcroot:
+    description: The path to a .xcroot to use for building and/or testing. See also `xcodebuild`'s `-xcroot`.
+    required: false
+  xctestrun:
+    description: The path to a test run specification. See also `xcodebuild`'s `-xctestrun`.
+    required: false
+  test-plan:
+    description: The name of the test plan associated with the scheme to use for testing. See also `xcodebuild`'s `-testPlan`.
     required: false
   skip-testing:
     description: A list of tests to skip. See also `xcodebuild`'s `-skip-testing`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,31 @@
 {
   "name": "xcodebuild-action",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@actions/core": "^1.2.6"
+      },
+      "devDependencies": {
+        "@types/node": "^12.19.4"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "node_modules/@types/node": {
+      "version": "12.20.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
+      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "@actions/core": {
       "version": "1.2.6",
@@ -10,9 +33,9 @@
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@types/node": {
-      "version": "12.19.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
-      "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==",
+      "version": "12.20.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
+      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcodebuild-action",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "A GitHub action that runs xcodebuild.",
   "main": "dist/index.js",
   "scripts": {
@@ -13,7 +13,8 @@
     "url": "git+https://github.com/sersoft-gmbh/xcodebuild-action.git"
   },
   "keywords": [
-    "Xcode"
+    "Xcode",
+    "Xcodebuild"
   ],
   "author": "ser.soft GmbH",
   "license": "Apache-2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,12 +133,17 @@ async function main() {
     addFlagArg('parallelize-targets', 'parallelizeTargets');
     addBoolArg('enable-code-coverage', 'enableCodeCoverage');
     addBoolArg('parallel-testing-enabled');
+    addFlagArg('quiet');
+    addFlagArg('hide-shell-script-environment', 'hideShellScriptEnvironment');
     addBoolArg('enable-address-sanitizer', 'enableAddressSanitizer');
     addBoolArg('enable-thread-sanitizer', 'enableThreadSanitizer');
     addBoolArg('enable-undefined-behavior-sanitizer', 'enableUndefinedBehaviorSanitizer');
     addInputArg('result-bundle-path', 'resultBundlePath');
     addInputArg('result-bundle-version', 'resultBundleVersion');
     addInputArg('derived-data-path', 'derivedDataPath');
+    addInputArg('xcroot');
+    addInputArg('xctestrun');
+    addInputArg('test-plan', 'testPlan');
     addInputArg('skip-testing');
     addFlagArg('skip-unavailable-actions', 'skipUnavailableActions');
     addFlagArg('allow-provisioning-updates', 'allowProvisioningUpdates');


### PR DESCRIPTION
This add's a bunch of new options - including support for test plans:

- `quiet` (`-quiet` in `xcodebuild`)
- `hide-shell-script-environment`  (`-hideShellScriptEnvironment` in `xcodebuild`)
- `xcroot` (`-xcroot` in `xcodebuild`)
- `xctestrun` (`-xctestrun ` in `xcodebuild`)
- `test-plan` (`-testPlan ` in `xcodebuild`)

This fixes #10.